### PR TITLE
Add OpenAI-powered tab organizer extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,57 @@
-# TabOrgAI
+# Tab Organizer AI
+
+A minimal, production-ready Chrome extension (Manifest V3) that uses your own OpenAI API key to deduplicate and group the tabs in your current Chrome window.
+
+## Features
+
+- Securely stores your OpenAI API key and preferred model in `chrome.storage.sync`.
+- Smart duplicate detection that keeps the most relevant tab (active/pinned/recent) and closes extras.
+- AI-powered grouping that creates or updates Chrome tab groups using concise intent-based names.
+- Dry-run preview option to inspect the plan before applying changes.
+- Respect for pinned tabs and per-domain safeguards.
+
+## Installation
+
+1. Clone or download this repository.
+2. Open **chrome://extensions** in Chrome.
+3. Enable **Developer mode** in the top-right corner.
+4. Click **Load unpacked** and select the folder containing this project.
+
+## Configuration
+
+1. In the extensions list, click **Details** for Tab Organizer AI and open the **Extension options** page.
+2. Enter your OpenAI API key (starts with `sk-`) and optionally choose a model (defaults to `gpt-4o-mini`).
+3. Adjust preferences:
+   - Keep at least one tab per domain.
+   - Preserve pinned tabs.
+   - Maximum tabs per group.
+   - Dry-run preview before applying changes.
+4. Click **Save changes**. The key and settings are stored locally via `chrome.storage.sync` and only used to call the OpenAI API.
+
+## Usage
+
+1. Open the popup from the extension toolbar.
+2. Provide optional guidance in the multiline field (e.g., "Group by project" or "Prioritize research vs entertainment").
+3. Press **Organize**.
+   - If dry-run is enabled, review the preview and press **Apply plan** to execute.
+   - Otherwise, the service worker will immediately close duplicates, create/update tab groups, and tidy empty ones.
+4. Status updates and any errors are shown at the bottom of the popup.
+
+## Permissions rationale
+
+- `storage`: save your API key, model, and organization preferences.
+- `tabs`: read metadata (title, URL, pinned, active) and close duplicates in the current window.
+- `tabGroups`: create, update, and clean up Chrome tab groups during organization.
+- `host_permissions` (`<all_urls>`): required to read tab URLs for deduplication and grouping context; no network requests are made to page content.
+
+## Privacy & network behavior
+
+- The extension uses your API key exclusively to call `https://api.openai.com/v1/chat/completions`.
+- No analytics, telemetry, or third-party network calls.
+- All processing happens in the background service worker—no content scripts are injected into web pages.
+
+## Development notes
+
+- Built with plain HTML, CSS, and JavaScript (no bundlers).
+- Manifest V3 with an ES module service worker.
+- Code is organized into small modules: `llm.js` for OpenAI calls, `tab_utils.js` for tab analysis, and UI scripts for popup/options pages.

--- a/llm.js
+++ b/llm.js
@@ -1,0 +1,76 @@
+/**
+ * Helper utilities for interacting with the OpenAI Chat Completions API.
+ * @module llm
+ */
+
+export const DEFAULT_MODEL = 'gpt-4o-mini';
+const OPENAI_ENDPOINT = 'https://api.openai.com/v1/chat/completions';
+
+/**
+ * Load the API key and model preference from chrome.storage.sync.
+ * @returns {Promise<{apiKey: string, model: string}>}
+ */
+export async function getStoredOpenAIConfig() {
+  const stored = await chrome.storage.sync.get({ apiKey: '', model: DEFAULT_MODEL });
+  const apiKey = typeof stored.apiKey === 'string' ? stored.apiKey.trim() : '';
+  const model = typeof stored.model === 'string' && stored.model.trim() ? stored.model.trim() : DEFAULT_MODEL;
+  return { apiKey, model };
+}
+
+/**
+ * Call the OpenAI Chat Completions API.
+ * @param {{ messages: Array<{role: 'system'|'user'|'assistant', content: string}>, model?: string, temperature?: number, signal?: AbortSignal }} params
+ * @returns {Promise<any>}
+ */
+export async function requestChatCompletion(params) {
+  const { messages, model: explicitModel, temperature = 0.2, signal } = params;
+  if (!Array.isArray(messages) || messages.length === 0) {
+    throw new Error('Missing messages for chat completion request.');
+  }
+
+  const { apiKey, model } = await getStoredOpenAIConfig();
+  if (!apiKey) {
+    throw new Error('OpenAI API key is not set. Please open the extension options and add it.');
+  }
+
+  const payload = {
+    model: explicitModel || model || DEFAULT_MODEL,
+    messages,
+    temperature,
+    response_format: { type: 'json_object' }
+  };
+
+  const response = await fetch(OPENAI_ENDPOINT, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`
+    },
+    body: JSON.stringify(payload),
+    signal
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`OpenAI request failed: ${response.status} ${response.statusText} - ${errorText}`);
+  }
+
+  return response.json();
+}
+
+/**
+ * Parse the primary message content from a chat completion result.
+ * @param {any} completion
+ * @returns {string}
+ */
+export function extractMessageContent(completion) {
+  const choice = completion?.choices?.[0];
+  if (!choice) {
+    throw new Error('Unexpected OpenAI response format.');
+  }
+  const content = choice.message?.content;
+  if (typeof content !== 'string' || !content.trim()) {
+    throw new Error('OpenAI response did not include content.');
+  }
+  return content.trim();
+}

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,23 @@
+{
+  "manifest_version": 3,
+  "name": "Tab Organizer AI",
+  "version": "1.0.0",
+  "description": "Organize the current Chrome window's tabs with OpenAI-powered clustering and smart deduping.",
+  "action": {
+    "default_title": "Organize Tabs",
+    "default_popup": "popup.html"
+  },
+  "background": {
+    "service_worker": "service_worker.js",
+    "type": "module"
+  },
+  "options_page": "options.html",
+  "permissions": [
+    "storage",
+    "tabs",
+    "tabGroups"
+  ],
+  "host_permissions": [
+    "<all_urls>"
+  ]
+}

--- a/options.html
+++ b/options.html
@@ -1,0 +1,123 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Tab Organizer AI – Options</title>
+    <style>
+      :root {
+        color-scheme: light;
+        font-family: "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
+        background: #f8fafc;
+        color: #0f172a;
+      }
+      body {
+        margin: 0;
+      }
+      main {
+        max-width: 560px;
+        margin: 0 auto;
+        padding: 24px 16px 48px;
+        display: flex;
+        flex-direction: column;
+        gap: 16px;
+      }
+      h1 {
+        margin: 0;
+        font-size: 1.5rem;
+      }
+      form {
+        display: grid;
+        gap: 16px;
+      }
+      label {
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+        font-size: 0.95rem;
+        font-weight: 500;
+      }
+      input[type="text"],
+      input[type="password"],
+      input[type="number"] {
+        padding: 10px;
+        border-radius: 8px;
+        border: 1px solid #cbd5f5;
+        font-size: 1rem;
+        font-family: inherit;
+        background: #ffffff;
+      }
+      input:focus {
+        outline: 2px solid #2563eb;
+        outline-offset: 1px;
+      }
+      .checkbox-group {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        font-weight: 500;
+      }
+      button {
+        justify-self: start;
+        padding: 10px 18px;
+        border-radius: 999px;
+        border: none;
+        background: #2563eb;
+        color: #ffffff;
+        font-size: 1rem;
+        font-weight: 600;
+        cursor: pointer;
+      }
+      button:focus-visible {
+        outline: 2px solid #1e40af;
+        outline-offset: 2px;
+      }
+      #status {
+        min-height: 20px;
+        font-size: 0.9rem;
+        color: #0f172a;
+      }
+      small {
+        color: #475569;
+        font-size: 0.8rem;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>Tab Organizer settings</h1>
+      <p>Store your OpenAI key and choose how the extension handles duplicates and tab groups.</p>
+      <form id="options-form">
+        <label for="apiKey">
+          OpenAI API key
+          <input id="apiKey" name="apiKey" type="password" autocomplete="off" placeholder="sk-..." required />
+          <small>Stored locally using chrome.storage.sync and used only for OpenAI requests.</small>
+        </label>
+        <label for="model">
+          Model name
+          <input id="model" name="model" type="text" placeholder="gpt-4o-mini" />
+          <small>Use any compatible Chat Completions model from your OpenAI account.</small>
+        </label>
+        <label class="checkbox-group">
+          <input type="checkbox" id="keepDomain" name="keepDomain" />
+          Keep at least one tab per domain
+        </label>
+        <label class="checkbox-group">
+          <input type="checkbox" id="preservePinned" name="preservePinned" />
+          Preserve pinned tabs
+        </label>
+        <label for="maxTabs">
+          Max tabs per group
+          <input id="maxTabs" name="maxTabs" type="number" min="2" max="24" step="1" />
+        </label>
+        <label class="checkbox-group">
+          <input type="checkbox" id="dryRun" name="dryRun" />
+          Enable dry-run preview before applying changes
+        </label>
+        <button type="submit">Save changes</button>
+        <p id="status" role="status" aria-live="polite"></p>
+      </form>
+    </main>
+    <script type="module" src="options.js"></script>
+  </body>
+</html>

--- a/options.js
+++ b/options.js
@@ -1,0 +1,55 @@
+import { DEFAULT_MODEL } from './llm.js';
+
+const form = document.getElementById('options-form');
+const statusEl = document.getElementById('status');
+
+const DEFAULTS = {
+  apiKey: '',
+  model: DEFAULT_MODEL,
+  keepAtLeastOnePerDomain: true,
+  preservePinned: true,
+  maxTabsPerGroup: 6,
+  dryRun: false
+};
+
+async function restoreOptions() {
+  try {
+    const stored = await chrome.storage.sync.get(DEFAULTS);
+    form.apiKey.value = typeof stored.apiKey === 'string' ? stored.apiKey : '';
+    form.model.value = typeof stored.model === 'string' ? stored.model : DEFAULT_MODEL;
+    form.keepDomain.checked = stored.keepAtLeastOnePerDomain !== false;
+    form.preservePinned.checked = stored.preservePinned !== false;
+    form.maxTabs.value = Number.isFinite(Number(stored.maxTabsPerGroup)) ? stored.maxTabsPerGroup : DEFAULTS.maxTabsPerGroup;
+    form.dryRun.checked = Boolean(stored.dryRun);
+    setStatus('');
+  } catch (error) {
+    console.error('Failed to restore options', error);
+    setStatus('Unable to load saved settings.');
+  }
+}
+
+form.addEventListener('submit', async (event) => {
+  event.preventDefault();
+  const maxTabsValue = Math.max(2, Number(form.maxTabs.value) || DEFAULTS.maxTabsPerGroup);
+  const payload = {
+    apiKey: form.apiKey.value.trim(),
+    model: form.model.value.trim() || DEFAULT_MODEL,
+    keepAtLeastOnePerDomain: form.keepDomain.checked,
+    preservePinned: form.preservePinned.checked,
+    maxTabsPerGroup: maxTabsValue,
+    dryRun: form.dryRun.checked
+  };
+  try {
+    await chrome.storage.sync.set(payload);
+    setStatus('Settings saved.');
+  } catch (error) {
+    console.error('Failed to save options', error);
+    setStatus('Unable to save settings.');
+  }
+});
+
+function setStatus(message) {
+  statusEl.textContent = message;
+}
+
+restoreOptions();

--- a/popup.css
+++ b/popup.css
@@ -1,0 +1,123 @@
+:root {
+  color-scheme: light;
+  font-family: "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
+  background-color: #f8fafc;
+  color: #0f172a;
+}
+
+body {
+  margin: 0;
+  min-width: 320px;
+}
+
+main {
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+h1 {
+  margin: 0;
+  font-size: 1.15rem;
+  font-weight: 600;
+}
+
+form {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+label {
+  font-size: 0.85rem;
+  font-weight: 500;
+}
+
+textarea {
+  resize: vertical;
+  min-height: 88px;
+  padding: 8px;
+  border: 1px solid #cbd5f5;
+  border-radius: 8px;
+  font-family: inherit;
+  font-size: 0.95rem;
+  line-height: 1.4;
+  background-color: #ffffff;
+  color: inherit;
+}
+
+textarea:focus {
+  outline: 2px solid #2563eb;
+  outline-offset: 1px;
+}
+
+button {
+  border: none;
+  background-color: #2563eb;
+  color: #ffffff;
+  padding: 10px 14px;
+  border-radius: 999px;
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+button:focus-visible {
+  outline: 2px solid #1e40af;
+  outline-offset: 2px;
+}
+
+button:hover {
+  background-color: #1d4ed8;
+}
+
+button:disabled {
+  background-color: #94a3b8;
+  cursor: not-allowed;
+}
+
+#preview {
+  border-top: 1px solid #e2e8f0;
+  padding-top: 12px;
+}
+
+#preview h2 {
+  margin: 0 0 8px;
+  font-size: 1rem;
+}
+
+.preview-section {
+  margin-bottom: 8px;
+}
+
+.preview-section h3 {
+  margin: 0 0 4px;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #64748b;
+}
+
+.preview-list {
+  margin: 0;
+  padding-left: 18px;
+  font-size: 0.85rem;
+}
+
+.preview-list li {
+  margin-bottom: 4px;
+}
+
+#status {
+  min-height: 20px;
+  font-size: 0.85rem;
+  color: #1e293b;
+}
+
+@media (max-width: 360px) {
+  main {
+    padding: 12px;
+  }
+}

--- a/popup.html
+++ b/popup.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Tab Organizer AI</title>
+    <link rel="stylesheet" href="popup.css" />
+  </head>
+  <body>
+    <main>
+      <h1>Organize tabs</h1>
+      <form id="organize-form">
+        <label for="organize-input">Tell me how to organize</label>
+        <textarea
+          id="organize-input"
+          name="prompt"
+          rows="4"
+          placeholder="e.g., Group by project and close social media duplicates"
+        ></textarea>
+        <button type="submit" id="organize-button">Organize</button>
+      </form>
+      <section id="preview" hidden>
+        <h2>Planned changes</h2>
+        <div id="preview-content"></div>
+      </section>
+      <p id="status" role="status" aria-live="polite"></p>
+    </main>
+    <script type="module" src="popup.js"></script>
+  </body>
+</html>

--- a/popup.js
+++ b/popup.js
@@ -1,0 +1,149 @@
+const form = document.getElementById('organize-form');
+const textarea = document.getElementById('organize-input');
+const button = document.getElementById('organize-button');
+const statusEl = document.getElementById('status');
+const previewSection = document.getElementById('preview');
+const previewContent = document.getElementById('preview-content');
+
+let awaitingConfirmation = false;
+let previewToken = null;
+let previewPromptValue = '';
+
+form.addEventListener('submit', async (event) => {
+  event.preventDefault();
+
+  if (awaitingConfirmation && textarea.value.trim() !== previewPromptValue) {
+    resetPreview();
+  }
+
+  const confirm = awaitingConfirmation;
+  const prompt = textarea.value.trim();
+
+  setWorkingState(true, confirm ? 'Applying…' : 'Organizing…');
+
+  try {
+    const response = await chrome.runtime.sendMessage({
+      type: 'organize-tabs',
+      prompt,
+      confirm,
+      token: confirm ? previewToken : undefined
+    });
+
+    if (!response) {
+      throw new Error('No response from background script.');
+    }
+
+    if (!response.success) {
+      throw new Error(response.error || 'Unable to organize tabs.');
+    }
+
+    if (response.preview) {
+      previewToken = response.token;
+      awaitingConfirmation = true;
+      previewPromptValue = prompt;
+      renderPreview(response.summary);
+      setStatus(response.message || 'Review the plan and confirm.');
+      button.textContent = 'Apply plan';
+      button.disabled = false;
+      return;
+    }
+
+    setStatus(response.message || 'Tabs organized successfully.');
+    resetPreview();
+  } catch (error) {
+    console.error('Popup organize error', error);
+    setStatus(error.message || 'Unexpected error.');
+  } finally {
+    setWorkingState(false);
+  }
+});
+
+function setWorkingState(isWorking, label) {
+  button.disabled = isWorking;
+  if (label) {
+    button.textContent = label;
+  } else if (!awaitingConfirmation) {
+    button.textContent = 'Organize';
+  }
+  if (isWorking) {
+    setStatus('');
+  }
+}
+
+function setStatus(message) {
+  statusEl.textContent = message;
+}
+
+function renderPreview(summary) {
+  if (!summary) {
+    resetPreview();
+    return;
+  }
+  previewContent.innerHTML = '';
+
+  const closingSection = document.createElement('div');
+  closingSection.className = 'preview-section';
+  const closingTitle = document.createElement('h3');
+  closingTitle.textContent = 'Tabs to close';
+  closingSection.appendChild(closingTitle);
+  const closingList = document.createElement('ul');
+  closingList.className = 'preview-list';
+  if (summary.closing.length) {
+    for (const item of summary.closing) {
+      const li = document.createElement('li');
+      li.textContent = `${item.title} – ${item.url}`;
+      closingList.appendChild(li);
+    }
+  } else {
+    const li = document.createElement('li');
+    li.textContent = 'No duplicates will be closed.';
+    closingList.appendChild(li);
+  }
+  closingSection.appendChild(closingList);
+  previewContent.appendChild(closingSection);
+
+  const groupingSection = document.createElement('div');
+  groupingSection.className = 'preview-section';
+  const groupingTitle = document.createElement('h3');
+  groupingTitle.textContent = 'Tab groups';
+  groupingSection.appendChild(groupingTitle);
+  const groupingList = document.createElement('ul');
+  groupingList.className = 'preview-list';
+  if (summary.groups.length) {
+    for (const group of summary.groups) {
+      const li = document.createElement('li');
+      const tabList = group.tabs.map((tab) => tab.title).join(', ');
+      li.textContent = `${group.name}: ${tabList}`;
+      groupingList.appendChild(li);
+    }
+  } else {
+    const li = document.createElement('li');
+    li.textContent = 'No changes to tab groups.';
+    groupingList.appendChild(li);
+  }
+  groupingSection.appendChild(groupingList);
+  previewContent.appendChild(groupingSection);
+
+  if (summary.notes) {
+    const notesSection = document.createElement('div');
+    notesSection.className = 'preview-section';
+    const notesTitle = document.createElement('h3');
+    notesTitle.textContent = 'Notes';
+    const notesBody = document.createElement('p');
+    notesBody.textContent = summary.notes;
+    notesSection.appendChild(notesTitle);
+    notesSection.appendChild(notesBody);
+    previewContent.appendChild(notesSection);
+  }
+
+  previewSection.hidden = false;
+}
+
+function resetPreview() {
+  awaitingConfirmation = false;
+  previewToken = null;
+  previewPromptValue = '';
+  previewSection.hidden = true;
+  previewContent.innerHTML = '';
+  button.textContent = 'Organize';
+}

--- a/service_worker.js
+++ b/service_worker.js
@@ -1,0 +1,371 @@
+import { requestChatCompletion, extractMessageContent, DEFAULT_MODEL } from './llm.js';
+import {
+  fetchCurrentWindowTabs,
+  computeDedupePlan,
+  sanitizeGroupPlan,
+  summarizePlanForPreview,
+  extractDomain
+} from './tab_utils.js';
+
+const RATE_LIMIT_INTERVAL_MS = 5000;
+const PREVIEW_TTL_MS = 5 * 60 * 1000;
+const TAB_GROUP_ID_NONE = chrome.tabGroups?.TAB_GROUP_ID_NONE ?? -1;
+
+const DEFAULT_SYNC_SETTINGS = {
+  apiKey: '',
+  model: DEFAULT_MODEL,
+  keepAtLeastOnePerDomain: true,
+  preservePinned: true,
+  maxTabsPerGroup: 6,
+  dryRun: false
+};
+
+let lastCompletionTimestamp = 0;
+const previewPlans = new Map();
+
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (!message || message.type !== 'organize-tabs') {
+    return false;
+  }
+  handleOrganizeMessage(message)
+    .then((result) => sendResponse(result))
+    .catch((error) => {
+      console.error('[Tab Organizer AI] organize-tabs error', error);
+      sendResponse({ success: false, error: error.message || 'Unexpected error' });
+    });
+  return true;
+});
+
+/**
+ * Process organize requests coming from the popup UI.
+ * @param {{ prompt?: string, confirm?: boolean, token?: string }} message
+ */
+async function handleOrganizeMessage(message) {
+  const preferences = await loadPreferences();
+  cleanupExpiredPreviews();
+
+  if (!preferences.apiKey) {
+    throw new Error('Add your OpenAI API key in the extension options before organizing.');
+  }
+
+  const userPrompt = typeof message.prompt === 'string' ? message.prompt.trim() : '';
+  const isConfirm = Boolean(message.confirm);
+
+  if (preferences.dryRun && !isConfirm) {
+    const plan = await buildPlan(userPrompt, preferences, { skipRateLimit: false });
+    const token = crypto.randomUUID();
+    previewPlans.set(token, { plan, createdAt: Date.now() });
+    return {
+      success: true,
+      preview: true,
+      token,
+      summary: plan.preview,
+      message: buildPreviewMessage(plan)
+    };
+  }
+
+  if (isConfirm && message.token) {
+    const stored = previewPlans.get(message.token);
+    if (!stored) {
+      throw new Error('Preview expired. Please analyze the tabs again.');
+    }
+    previewPlans.delete(message.token);
+    const applyResult = await applyPlan(stored.plan);
+    return { success: true, preview: false, ...applyResult };
+  }
+
+  const plan = await buildPlan(userPrompt, preferences, { skipRateLimit: false });
+  const applyResult = await applyPlan(plan);
+  return { success: true, preview: false, ...applyResult };
+}
+
+/**
+ * Create a detailed organization plan without mutating tabs.
+ * @param {string} userPrompt
+ * @param {ReturnType<typeof loadPreferences>} preferences
+ * @param {{skipRateLimit?: boolean}} [options]
+ */
+async function buildPlan(userPrompt, preferences, options = {}) {
+  const { windowId, tabs } = await fetchCurrentWindowTabs();
+  if (!tabs.length) {
+    throw new Error('No tabs were found in the current window.');
+  }
+
+  const dedupe = computeDedupePlan(tabs, preferences);
+  const survivorsSet = new Set(dedupe.survivors.map((tab) => tab.id));
+  const survivors = tabs.filter((tab) => survivorsSet.has(tab.id));
+  const tabLookup = new Map(tabs.map((tab) => [tab.id, tab]));
+
+  let grouping = { groups: [], assignedTabIds: new Set(), notes: '' };
+  if (survivors.length >= 2) {
+    const groupingResult = await fetchGroupingFromLLM({
+      windowId,
+      tabs: survivors,
+      preferences,
+      userPrompt,
+      skipRateLimit: Boolean(options.skipRateLimit)
+    });
+    const sanitized = sanitizeGroupPlan(groupingResult.groups, survivors, preferences);
+    grouping = {
+      groups: sanitized.groups,
+      assignedTabIds: sanitized.assignedTabIds,
+      notes: groupingResult.notes || ''
+    };
+  }
+
+  const preview = summarizePlanForPreview({
+    tabsToClose: dedupe.tabsToClose,
+    grouping,
+    tabLookup,
+    notes: grouping.notes
+  });
+
+  return {
+    windowId,
+    tabs,
+    preferences,
+    dedupe,
+    grouping,
+    tabLookup,
+    preview,
+    userPrompt
+  };
+}
+
+/**
+ * Apply the stored plan to the live Chrome tabs.
+ * @param {{ windowId: number, dedupe: any, grouping: any, preferences: any }} plan
+ */
+async function applyPlan(plan) {
+  const { windowId, dedupe, grouping, preferences } = plan;
+
+  const currentTabs = await chrome.tabs.query({ windowId });
+  const tabMap = new Map(currentTabs.map((tab) => [tab.id, tab]));
+
+  const removalIds = [];
+  for (const item of dedupe.tabsToClose) {
+    const tab = tabMap.get(item.id);
+    if (!tab) continue;
+    if (preferences.preservePinned && tab.pinned) continue;
+    removalIds.push(item.id);
+  }
+
+  if (removalIds.length) {
+    try {
+      await chrome.tabs.remove(removalIds);
+    } catch (error) {
+      console.warn('Failed to remove some duplicate tabs', error);
+    }
+  }
+
+  const tabsAfterRemoval = await chrome.tabs.query({ windowId });
+  const afterRemovalMap = new Map(tabsAfterRemoval.map((tab) => [tab.id, tab]));
+  const plannedAssignments = [];
+  const assignedTabs = new Set();
+
+  for (const group of grouping.groups) {
+    const ids = [];
+    for (const tabId of group.tabIds) {
+      if (assignedTabs.has(tabId)) continue;
+      const tab = afterRemovalMap.get(tabId);
+      if (!tab) continue;
+      if (preferences.preservePinned && tab.pinned) continue;
+      ids.push(tabId);
+      assignedTabs.add(tabId);
+    }
+    if (!ids.length) continue;
+    try {
+      const groupId = await chrome.tabs.group({ tabIds: ids });
+      await chrome.tabGroups.update(groupId, { title: group.name });
+      plannedAssignments.push({ groupId, name: group.name, tabIds: ids });
+    } catch (error) {
+      console.warn('Failed to apply tab group', group, error);
+    }
+  }
+
+  // Ungroup tabs that are no longer assigned to a group.
+  for (const tab of tabsAfterRemoval) {
+    if (tab.groupId === TAB_GROUP_ID_NONE) continue;
+    if (assignedTabs.has(tab.id)) continue;
+    try {
+      await chrome.tabs.ungroup(tab.id);
+    } catch (error) {
+      console.warn('Failed to ungroup tab', tab.id, error);
+    }
+  }
+
+  await cleanupEmptyGroups(windowId);
+
+  const closedCount = removalIds.length;
+  const groupedCount = plannedAssignments.length;
+
+  return {
+    message: buildCompletionMessage({ closedCount, groupedCount }),
+    details: {
+      closedCount,
+      groupedCount,
+      groups: plannedAssignments
+    }
+  };
+}
+
+/**
+ * Fetch LLM grouping suggestions.
+ * @param {{windowId: number, tabs: any[], preferences: any, userPrompt: string, skipRateLimit: boolean}} params
+ */
+async function fetchGroupingFromLLM(params) {
+  const { windowId, tabs, preferences, userPrompt, skipRateLimit } = params;
+  if (!skipRateLimit) {
+    enforceRateLimit();
+  }
+
+  const tabPayload = tabs.map((tab) => ({
+    id: tab.id,
+    title: tab.title,
+    url: tab.url,
+    domain: extractDomain(tab.url),
+    pinned: Boolean(tab.pinned),
+    audible: Boolean(tab.audible),
+    active: Boolean(tab.active)
+  }));
+
+  const systemPrompt = [
+    'You are an assistant that organizes browser tabs into small, meaningful groups.',
+    'Return JSON with the shape {"groups":[{"name":"string","tabIds":[number,...]}],"notes":"string"}.',
+    `Limit each group to ${Math.max(2, Number(preferences.maxTabsPerGroup) || 6)} tabs or fewer.`,
+    'Only include tab IDs that you were provided.',
+    'Skip grouping pinned tabs and only group items that have a clear common task or theme.',
+    'Prefer short titles (<= 20 characters) that summarize the intent. Avoid emoji unless it conveys clear meaning.',
+    'Leave tabs out of all groups when no obvious grouping exists.'
+  ].join(' ');
+
+  const userContent = JSON.stringify({
+    windowId,
+    preferences: {
+      keepAtLeastOnePerDomain: Boolean(preferences.keepAtLeastOnePerDomain),
+      preservePinned: Boolean(preferences.preservePinned),
+      maxTabsPerGroup: Math.max(2, Number(preferences.maxTabsPerGroup) || 6)
+    },
+    userPrompt: userPrompt || null,
+    tabs: tabPayload
+  });
+
+  const completion = await requestChatCompletion({
+    model: preferences.model || DEFAULT_MODEL,
+    temperature: 0.2,
+    messages: [
+      { role: 'system', content: systemPrompt },
+      {
+        role: 'user',
+        content:
+          'Analyze the following tabs and suggest topic-based groups. Respect the `userPrompt` guidance when provided. ' +
+          'Respond with valid JSON and do not add any extra commentary.\n' +
+          userContent
+      }
+    ]
+  });
+
+  lastCompletionTimestamp = Date.now();
+
+  const content = extractMessageContent(completion);
+  let parsed;
+  try {
+    parsed = JSON.parse(content);
+  } catch (error) {
+    throw new Error('OpenAI returned an invalid grouping payload.');
+  }
+
+  const groups = Array.isArray(parsed.groups) ? parsed.groups : [];
+  const notes = typeof parsed.notes === 'string' ? parsed.notes : '';
+  return { groups, notes };
+}
+
+/**
+ * Load persisted preferences with defaults.
+ */
+async function loadPreferences() {
+  const stored = await chrome.storage.sync.get(DEFAULT_SYNC_SETTINGS);
+  return {
+    apiKey: typeof stored.apiKey === 'string' ? stored.apiKey.trim() : '',
+    model: typeof stored.model === 'string' && stored.model.trim() ? stored.model.trim() : DEFAULT_MODEL,
+    keepAtLeastOnePerDomain: stored.keepAtLeastOnePerDomain !== false,
+    preservePinned: stored.preservePinned !== false,
+    maxTabsPerGroup: Math.max(2, Number(stored.maxTabsPerGroup) || 6),
+    dryRun: Boolean(stored.dryRun)
+  };
+}
+
+/**
+ * Ensure OpenAI calls are rate limited.
+ */
+function enforceRateLimit() {
+  const now = Date.now();
+  if (now - lastCompletionTimestamp < RATE_LIMIT_INTERVAL_MS) {
+    const waitMs = RATE_LIMIT_INTERVAL_MS - (now - lastCompletionTimestamp);
+    throw new Error(`Please wait ${Math.ceil(waitMs / 1000)} more second(s) before organizing again.`);
+  }
+}
+
+/**
+ * Remove preview plans that are older than the TTL.
+ */
+function cleanupExpiredPreviews() {
+  const now = Date.now();
+  for (const [token, value] of previewPlans.entries()) {
+    if (now - value.createdAt > PREVIEW_TTL_MS) {
+      previewPlans.delete(token);
+    }
+  }
+}
+
+/**
+ * Delete any empty tab groups that remain.
+ * @param {number} windowId
+ */
+async function cleanupEmptyGroups(windowId) {
+  try {
+    const groups = await chrome.tabGroups.query({ windowId });
+    for (const group of groups) {
+      const tabs = await chrome.tabs.query({ windowId, groupId: group.id });
+      if (!tabs.length) {
+        try {
+          await chrome.tabGroups.delete(group.id);
+        } catch (error) {
+          console.warn('Failed to delete empty group', group.id, error);
+        }
+      }
+    }
+  } catch (error) {
+    console.warn('Unable to cleanup tab groups', error);
+  }
+}
+
+/**
+ * Build a user-facing message describing a preview.
+ * @param {{preview: any, dedupe: any}} plan
+ */
+function buildPreviewMessage(plan) {
+  const closingCount = plan.preview.closing.length;
+  const groupCount = plan.preview.groups.length;
+  const closingPart = closingCount ? `${closingCount} duplicate tab${closingCount === 1 ? '' : 's'} will close.` : 'No tabs will be closed.';
+  const groupingPart = groupCount ? `${groupCount} group${groupCount === 1 ? '' : 's'} will be updated.` : 'No tab groups will change.';
+  return `${closingPart} ${groupingPart}`;
+}
+
+/**
+ * Compose a completion status message.
+ * @param {{closedCount: number, groupedCount: number}} stats
+ */
+function buildCompletionMessage(stats) {
+  const parts = [];
+  if (stats.closedCount) {
+    parts.push(`Closed ${stats.closedCount} duplicate tab${stats.closedCount === 1 ? '' : 's'}.`);
+  }
+  if (stats.groupedCount) {
+    parts.push(`Updated ${stats.groupedCount} tab group${stats.groupedCount === 1 ? '' : 's'}.`);
+  }
+  if (!parts.length) {
+    parts.push('No changes were necessary.');
+  }
+  return parts.join(' ');
+}

--- a/tab_utils.js
+++ b/tab_utils.js
@@ -1,0 +1,288 @@
+/**
+ * Utility helpers for working with Chrome tabs.
+ * @module tab_utils
+ */
+
+/**
+ * @typedef {Object} OrganizePreferences
+ * @property {boolean} keepAtLeastOnePerDomain
+ * @property {boolean} preservePinned
+ * @property {number} maxTabsPerGroup
+ */
+
+/**
+ * @typedef {Object} TabSnapshot
+ * @property {number} id
+ * @property {string} title
+ * @property {string} url
+ * @property {boolean} pinned
+ * @property {boolean} audible
+ * @property {boolean} active
+ * @property {number} groupId
+ * @property {number} index
+ * @property {number|undefined} lastAccessed
+ */
+
+/**
+ * Capture only the tab fields that are needed for planning.
+ * @param {chrome.tabs.Tab} tab
+ * @returns {TabSnapshot}
+ */
+export function snapshotTab(tab) {
+  return {
+    id: tab.id ?? -1,
+    title: tab.title ?? 'Untitled',
+    url: tab.url ?? '',
+    pinned: Boolean(tab.pinned),
+    audible: Boolean(tab.audible),
+    active: Boolean(tab.active),
+    groupId: typeof tab.groupId === 'number' ? tab.groupId : chrome.tabGroups ? chrome.tabGroups.TAB_GROUP_ID_NONE : -1,
+    index: typeof tab.index === 'number' ? tab.index : 0,
+    lastAccessed: typeof tab.lastAccessed === 'number' ? tab.lastAccessed : undefined
+  };
+}
+
+/**
+ * Get tabs from the current Chrome window.
+ * @returns {Promise<{windowId: number, tabs: TabSnapshot[]}>}
+ */
+export async function fetchCurrentWindowTabs() {
+  const win = await chrome.windows.getCurrent({ populate: true });
+  if (!win || !Array.isArray(win.tabs)) {
+    throw new Error('Unable to read tabs for the current window.');
+  }
+  const snapshots = win.tabs
+    .filter((tab) => typeof tab.id === 'number')
+    .map((tab) => snapshotTab(tab));
+  return { windowId: win.id ?? -1, tabs: snapshots };
+}
+
+/**
+ * Attempt to normalize a URL to assist with deduplication.
+ * The canonical form keeps the hostname and pathname while stripping
+ * fragments and most query parameters.
+ * @param {string} rawUrl
+ * @returns {string|null}
+ */
+export function canonicalizeUrl(rawUrl) {
+  if (!rawUrl) return null;
+  try {
+    const url = new URL(rawUrl);
+    const pathname = url.pathname.replace(/\/$/, '');
+    const host = url.hostname.replace(/^www\./i, '').toLowerCase();
+    if (!host) return null;
+    return `${host}${pathname || ''}` || host;
+  } catch (error) {
+    return null;
+  }
+}
+
+/**
+ * Extract a normalized domain/hostname for summary and policies.
+ * @param {string} rawUrl
+ * @returns {string|null}
+ */
+export function extractDomain(rawUrl) {
+  if (!rawUrl) return null;
+  try {
+    const url = new URL(rawUrl);
+    return url.hostname.replace(/^www\./i, '').toLowerCase();
+  } catch (error) {
+    return null;
+  }
+}
+
+/**
+ * Decide which tabs should be closed because they are duplicates.
+ * @param {TabSnapshot[]} tabs
+ * @param {OrganizePreferences} preferences
+ * @returns {{
+ *   tabsToClose: Array<{id: number, title: string, url: string, reason: string, duplicateOf: number}>,
+ *   survivors: TabSnapshot[],
+ *   duplicateSets: Array<{canonical: string|null, keeper: TabSnapshot, closing: TabSnapshot[]}>
+ * }}
+ */
+export function computeDedupePlan(tabs, preferences) {
+  const canonicalGroups = new Map();
+  const preferencePreservePinned = Boolean(preferences.preservePinned);
+  const keepAtLeastOnePerDomain = Boolean(preferences.keepAtLeastOnePerDomain);
+
+  for (const tab of tabs) {
+    const canonical = canonicalizeUrl(tab.url);
+    const key = canonical || `id-${tab.id}`;
+    if (!canonicalGroups.has(key)) {
+      canonicalGroups.set(key, []);
+    }
+    canonicalGroups.get(key).push(tab);
+  }
+
+  /** @type {Set<number>} */
+  const keepers = new Set();
+  /** @type {Array<{id: number, title: string, url: string, reason: string, duplicateOf: number, domain: string|null}>>} */
+  const toClose = [];
+  /** @type {Array<{canonical: string|null, keeper: TabSnapshot, closing: TabSnapshot[]}>} */
+  const duplicateSets = [];
+
+  for (const [canonicalKey, groupTabs] of canonicalGroups.entries()) {
+    if (groupTabs.length === 1) {
+      keepers.add(groupTabs[0].id);
+      continue;
+    }
+
+    const sorted = groupTabs.slice().sort((a, b) => compareTabsForKeeper(b, a, preferencePreservePinned));
+    const keeper = sorted[0];
+    keepers.add(keeper.id);
+    const duplicates = sorted.slice(1);
+    const canonical = canonicalKey.startsWith('id-') ? null : canonicalKey;
+    duplicateSets.push({ canonical, keeper, closing: duplicates });
+    for (const dup of duplicates) {
+      if (preferencePreservePinned && dup.pinned) {
+        keepers.add(dup.id);
+        continue;
+      }
+      toClose.push({
+        id: dup.id,
+        title: dup.title,
+        url: dup.url,
+        reason: `Duplicate of "${keeper.title}"`,
+        duplicateOf: keeper.id,
+        domain: extractDomain(dup.url)
+      });
+    }
+  }
+
+  // Enforce the per-domain requirement.
+  if (keepAtLeastOnePerDomain) {
+    const survivorDomainCounts = new Map();
+    for (const tab of tabs) {
+      if (!keepers.has(tab.id)) continue;
+      const domain = extractDomain(tab.url);
+      if (!domain) continue;
+      survivorDomainCounts.set(domain, (survivorDomainCounts.get(domain) || 0) + 1);
+    }
+
+    const filteredClosures = [];
+    for (const candidate of toClose) {
+      const domain = candidate.domain;
+      if (!domain) {
+        filteredClosures.push(candidate);
+        continue;
+      }
+      const survivors = survivorDomainCounts.get(domain) || 0;
+      if (survivors <= 0) {
+        keepers.add(candidate.id);
+      } else {
+        filteredClosures.push(candidate);
+      }
+    }
+    toClose.length = 0;
+    toClose.push(...filteredClosures);
+  }
+
+  const survivors = tabs.filter((tab) => keepers.has(tab.id) && !toClose.find((dup) => dup.id === tab.id));
+
+  return {
+    tabsToClose: toClose,
+    survivors,
+    duplicateSets
+  };
+}
+
+/**
+ * Compare two tabs to determine which should be the keeper.
+ * Higher scores should be kept.
+ * @param {TabSnapshot} left
+ * @param {TabSnapshot} right
+ * @param {boolean} preferPinned
+ * @returns {number}
+ */
+function compareTabsForKeeper(left, right, preferPinned) {
+  return scoreTab(left, preferPinned) - scoreTab(right, preferPinned);
+}
+
+/**
+ * Score a tab for dedupe decisions.
+ * @param {TabSnapshot} tab
+ * @param {boolean} preferPinned
+ * @returns {number}
+ */
+function scoreTab(tab, preferPinned) {
+  let score = 0;
+  if (tab.active) score += 10000;
+  if (tab.audible) score += 200;
+  if (preferPinned && tab.pinned) score += 8000;
+  if (!preferPinned && tab.pinned) score += 2000;
+  if (typeof tab.lastAccessed === 'number') score += tab.lastAccessed / 1000;
+  score += 100 - tab.index;
+  return score;
+}
+
+/**
+ * Clean up and constrain group assignments suggested by the LLM.
+ * @param {Array<{name?: string, tabIds?: number[]}>} llmGroups
+ * @param {TabSnapshot[]} availableTabs
+ * @param {{ maxTabsPerGroup: number, preservePinned: boolean }} preferences
+ * @returns {{ groups: Array<{name: string, tabIds: number[]}>, assignedTabIds: Set<number> }}
+ */
+export function sanitizeGroupPlan(llmGroups, availableTabs, preferences) {
+  const maxPerGroup = Math.max(2, Number(preferences.maxTabsPerGroup) || 6);
+  const preservePinned = Boolean(preferences.preservePinned);
+  const tabMap = new Map(availableTabs.map((tab) => [tab.id, tab]));
+  const assigned = new Set();
+  const cleaned = [];
+
+  for (const group of llmGroups || []) {
+    if (!group || !Array.isArray(group.tabIds)) continue;
+    const proposedName = (group.name || '').trim();
+    const name = proposedName ? truncateLabel(proposedName) : 'Group';
+    const ids = [];
+    for (const tabId of group.tabIds) {
+      if (ids.length >= maxPerGroup) break;
+      if (assigned.has(tabId)) continue;
+      const tab = tabMap.get(tabId);
+      if (!tab) continue;
+      if (preservePinned && tab.pinned) continue;
+      ids.push(tabId);
+      assigned.add(tabId);
+    }
+    if (ids.length) {
+      cleaned.push({ name, tabIds: ids });
+    }
+  }
+
+  return { groups: cleaned, assignedTabIds: assigned };
+}
+
+/**
+ * Create a short human-friendly preview description of a dedupe/group plan.
+ * @param {{
+ *  tabsToClose: Array<{id:number,title:string,url:string,reason:string}>,
+ *  grouping: { groups: Array<{name: string, tabIds: number[]}> },
+ *  tabLookup: Map<number, TabSnapshot>,
+ *  notes?: string
+ * }} plan
+ * @returns {{closing: Array<{title: string, url: string}>, groups: Array<{name: string, tabs: Array<{title: string, url: string}>}>, notes?: string}}
+ */
+export function summarizePlanForPreview(plan) {
+  const closing = plan.tabsToClose.map((item) => ({ title: item.title, url: item.url }));
+  const groups = [];
+  for (const group of plan.grouping.groups) {
+    const tabs = group.tabIds
+      .map((id) => plan.tabLookup.get(id))
+      .filter(Boolean)
+      .map((tab) => ({ title: tab.title, url: tab.url }));
+    groups.push({ name: group.name, tabs });
+  }
+  return { closing, groups, notes: plan.notes };
+}
+
+/**
+ * Make sure group labels are concise and readable.
+ * @param {string} label
+ * @returns {string}
+ */
+function truncateLabel(label) {
+  const trimmed = label.trim().replace(/\s+/g, ' ');
+  if (trimmed.length <= 24) return trimmed;
+  return `${trimmed.slice(0, 21)}…`;
+}


### PR DESCRIPTION
## Summary
- add a Manifest V3 extension scaffold with popup, options page, and service worker modules
- integrate OpenAI chat completions via stored API key for dedupe-aware grouping of current window tabs
- build dry-run preview, preference storage, and tab utility helpers for safe grouping/cleanup workflows

## Testing
- No automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68c9c91b6c808333afb6d7bcfe627e56