### PR TITLE
Add deterministic no-LLM organizer alongside LLM flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A minimal, production-ready Chrome extension (Manifest V3) that uses your own Op
 - AI-powered grouping that creates or updates Chrome tab groups using concise intent-based names.
 - Dry-run preview option to inspect the plan before applying changes.
 - Respect for pinned tabs and per-domain safeguards.
+- Offline "No-LLM" organizer that applies deterministic rules, grouping, and dry-run previews without calling OpenAI.
 
 ## Installation
 
@@ -32,10 +33,28 @@ A minimal, production-ready Chrome extension (Manifest V3) that uses your own Op
 
 1. Open the popup from the extension toolbar.
 2. Provide optional guidance in the multiline field (e.g., "Group by project" or "Prioritize research vs entertainment").
-3. Press **Organize**.
-   - If dry-run is enabled, review the preview and press **Apply plan** to execute.
-   - Otherwise, the service worker will immediately close duplicates, create/update tab groups, and tidy empty ones.
-4. Status updates and any errors are shown at the bottom of the popup.
+3. Choose how to organize:
+   - **Organize (LLM)** runs the OpenAI-powered planner. If dry-run is enabled you can review the preview and press **Apply plan**.
+   - **Organize (No-LLM)** stays offline and applies your deterministic rules. Enable *Dry-run (No-LLM)* in the popup to inspect the plan before committing.
+4. Status updates and any errors are shown at the bottom of the popup, e.g. `Closed 4 dupes · Organized 3 groups` or a dry-run summary.
+
+## No-LLM mode: rules, dry-run, and examples
+
+- Configure deterministic behaviour from the options page under **No-LLM organizer**:
+  - Keep at least one tab per domain, preserve pinned tabs, and optionally cap group size.
+  - Toggle the default *Dry-run (No-LLM)* behaviour.
+  - Provide custom rules as JSON. Each rule can include `name`, `host`, `title`, `path`, and optional `color` fields (regular expressions are supported).
+- The popup's *Dry-run (No-LLM)* checkbox temporarily overrides the saved preference.
+- Example custom rules:
+
+  ```json
+  [
+    { "name": "GitHub PRs", "host": "github\\.com", "path": "/pull" },
+    { "name": "Docs", "host": "(docs|drive)\\.google\\.com" }
+  ]
+  ```
+
+- When dry-run is enabled the popup renders the planned duplicates and tab groups so you can confirm before applying.
 
 ## Permissions rationale
 

--- a/options.html
+++ b/options.html
@@ -26,6 +26,10 @@
         margin: 0;
         font-size: 1.5rem;
       }
+      h2 {
+        margin: 16px 0 8px;
+        font-size: 1.1rem;
+      }
       form {
         display: grid;
         gap: 16px;
@@ -47,7 +51,21 @@
         font-family: inherit;
         background: #ffffff;
       }
+      textarea {
+        padding: 10px;
+        border-radius: 8px;
+        border: 1px solid #cbd5f5;
+        font-size: 0.95rem;
+        font-family: inherit;
+        background: #ffffff;
+        resize: vertical;
+        min-height: 160px;
+      }
       input:focus {
+        outline: 2px solid #2563eb;
+        outline-offset: 1px;
+      }
+      textarea:focus {
         outline: 2px solid #2563eb;
         outline-offset: 1px;
       }
@@ -88,6 +106,7 @@
       <h1>Tab Organizer settings</h1>
       <p>Store your OpenAI key and choose how the extension handles duplicates and tab groups.</p>
       <form id="options-form">
+        <h2>AI organizer</h2>
         <label for="apiKey">
           OpenAI API key
           <input id="apiKey" name="apiKey" type="password" autocomplete="off" placeholder="sk-..." required />
@@ -99,6 +118,13 @@
           <small>Use any compatible Chat Completions model from your OpenAI account.</small>
         </label>
         <label class="checkbox-group">
+          <input type="checkbox" id="dryRun" name="dryRun" />
+          Enable dry-run preview before applying changes (LLM)
+        </label>
+
+        <h2>No-LLM organizer</h2>
+        <p>Configure deterministic deduping and grouping behaviour when you organize without the language model.</p>
+        <label class="checkbox-group">
           <input type="checkbox" id="keepDomain" name="keepDomain" />
           Keep at least one tab per domain
         </label>
@@ -109,11 +135,18 @@
         <label for="maxTabs">
           Max tabs per group
           <input id="maxTabs" name="maxTabs" type="number" min="2" max="24" step="1" />
+          <small>Leave blank to use the default size.</small>
         </label>
         <label class="checkbox-group">
-          <input type="checkbox" id="dryRun" name="dryRun" />
-          Enable dry-run preview before applying changes
+          <input type="checkbox" id="dryRunNoLLM" name="dryRunNoLLM" />
+          Enable dry-run preview (No-LLM)
         </label>
+        <label for="userRules">
+          Custom grouping rules (JSON)
+          <textarea id="userRules" name="userRules" rows="8" spellcheck="false"></textarea>
+          <small>Provide an array of rules. Each rule can match <code>host</code>, <code>title</code>, or <code>path</code> using regular expressions.</small>
+        </label>
+
         <button type="submit">Save changes</button>
         <p id="status" role="status" aria-live="polite"></p>
       </form>

--- a/options.js
+++ b/options.js
@@ -1,4 +1,5 @@
 import { DEFAULT_MODEL } from './llm.js';
+import { parseUserRulesJSON } from './tab_utils.js';
 
 const form = document.getElementById('options-form');
 const statusEl = document.getElementById('status');
@@ -9,8 +10,22 @@ const DEFAULTS = {
   keepAtLeastOnePerDomain: true,
   preservePinned: true,
   maxTabsPerGroup: 6,
-  dryRun: false
+  dryRun: false,
+  dryRunNoLLM: false,
+  userRulesJSON: ''
 };
+
+const RULES_EXAMPLE = `[
+  {
+    "name": "GitHub PRs",
+    "host": "github\\.com",
+    "path": "/pull"
+  },
+  {
+    "name": "Docs",
+    "host": "(docs|drive)\\.google\\.com"
+  }
+]`;
 
 async function restoreOptions() {
   try {
@@ -21,6 +36,9 @@ async function restoreOptions() {
     form.preservePinned.checked = stored.preservePinned !== false;
     form.maxTabs.value = Number.isFinite(Number(stored.maxTabsPerGroup)) ? stored.maxTabsPerGroup : DEFAULTS.maxTabsPerGroup;
     form.dryRun.checked = Boolean(stored.dryRun);
+    form.dryRunNoLLM.checked = Boolean(stored.dryRunNoLLM);
+    const rulesValue = typeof stored.userRulesJSON === 'string' ? stored.userRulesJSON.trim() : '';
+    form.userRules.value = rulesValue || RULES_EXAMPLE;
     setStatus('');
   } catch (error) {
     console.error('Failed to restore options', error);
@@ -31,13 +49,42 @@ async function restoreOptions() {
 form.addEventListener('submit', async (event) => {
   event.preventDefault();
   const maxTabsValue = Math.max(2, Number(form.maxTabs.value) || DEFAULTS.maxTabsPerGroup);
+  const rawRules = form.userRules.value.trim();
+  let userRulesJSON = '';
+
+  if (rawRules) {
+    try {
+      const parsed = JSON.parse(rawRules);
+      if (!Array.isArray(parsed)) {
+        throw new Error('Rules must be an array');
+      }
+      const normalized = parseUserRulesJSON(rawRules);
+      for (const rule of normalized) {
+        for (const key of ['host', 'title', 'path']) {
+          const descriptor = rule[key];
+          if (!descriptor) continue;
+          // Throws if the pattern is invalid.
+          // eslint-disable-next-line no-new
+          new RegExp(descriptor.pattern, descriptor.flags || 'i');
+        }
+      }
+      userRulesJSON = rawRules;
+    } catch (error) {
+      console.error('Invalid custom rules JSON', error);
+      setStatus('Custom rules must be valid JSON (array of objects).');
+      return;
+    }
+  }
+
   const payload = {
     apiKey: form.apiKey.value.trim(),
     model: form.model.value.trim() || DEFAULT_MODEL,
     keepAtLeastOnePerDomain: form.keepDomain.checked,
     preservePinned: form.preservePinned.checked,
     maxTabsPerGroup: maxTabsValue,
-    dryRun: form.dryRun.checked
+    dryRun: form.dryRun.checked,
+    dryRunNoLLM: form.dryRunNoLLM.checked,
+    userRulesJSON
   };
   try {
     await chrome.storage.sync.set(payload);

--- a/popup.css
+++ b/popup.css
@@ -29,6 +29,16 @@ form {
   gap: 8px;
 }
 
+.button-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.button-row button {
+  flex: 1 1 140px;
+}
+
 label {
   font-size: 0.85rem;
   font-weight: 500;
@@ -76,6 +86,18 @@ button:hover {
 button:disabled {
   background-color: #94a3b8;
   cursor: not-allowed;
+}
+
+.checkbox-inline {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.85rem;
+  font-weight: 500;
+}
+
+.checkbox-inline input[type='checkbox'] {
+  margin: 0;
 }
 
 #preview {

--- a/popup.html
+++ b/popup.html
@@ -17,7 +17,14 @@
           rows="4"
           placeholder="e.g., Group by project and close social media duplicates"
         ></textarea>
-        <button type="submit" id="organize-button">Organize</button>
+        <div class="button-row">
+          <button type="submit" id="organize-llm">Organize (LLM)</button>
+          <button type="button" id="organize-nollm">Organize (No-LLM)</button>
+        </div>
+        <label class="checkbox-inline" for="dryRunNoLLM">
+          <input type="checkbox" id="dryRunNoLLM" name="dryRunNoLLM" />
+          Dry-run (No-LLM)
+        </label>
       </form>
       <section id="preview" hidden>
         <h2>Planned changes</h2>

--- a/tab_utils.js
+++ b/tab_utils.js
@@ -3,6 +3,52 @@
  * @module tab_utils
  */
 
+const TRACKING_PARAM_PREFIXES = ['utm_'];
+const TRACKING_PARAM_NAMES = ['gclid', 'fbclid', 'igshid', 'spm', 'ref', 'ref_src'];
+const VALID_GROUP_COLORS = new Set([
+  'grey',
+  'blue',
+  'red',
+  'yellow',
+  'green',
+  'pink',
+  'purple',
+  'cyan',
+  'orange'
+]);
+
+const DEFAULT_RULE_DEFINITIONS = [
+  { name: 'GitHub PRs', host: /github\.com/i, path: /\/pull\/\d+/i, color: 'green' },
+  { name: 'GitHub Issues', host: /github\.com/i, path: /\/issues?\//i, color: 'orange' },
+  {
+    name: 'Google Docs',
+    host: /(docs|drive)\.google\.com/i,
+    path: /\/(document|spreadsheets?|presentation|drive)/i,
+    color: 'blue'
+  },
+  {
+    name: 'Meetings',
+    host: /(meet\.google\.com|zoom\.us|teams\.microsoft\.com)/i,
+    color: 'purple'
+  },
+  {
+    name: 'Project Hubs',
+    host: /(linear\.app|asana\.com|app\.clickup\.com|notion\.so)/i,
+    color: 'cyan'
+  },
+  {
+    name: 'Social',
+    host: /(twitter\.com|x\.com|facebook\.com|instagram\.com|linkedin\.com|reddit\.com)/i,
+    color: 'pink'
+  },
+  {
+    name: 'Search',
+    host: /(google\.|bing\.|duckduckgo\.com)/i,
+    path: /(search|results?)/i,
+    color: 'yellow'
+  }
+];
+
 /**
  * @typedef {Object} OrganizePreferences
  * @property {boolean} keepAtLeastOnePerDomain
@@ -68,10 +114,22 @@ export function canonicalizeUrl(rawUrl) {
   if (!rawUrl) return null;
   try {
     const url = new URL(rawUrl);
-    const pathname = url.pathname.replace(/\/$/, '');
     const host = url.hostname.replace(/^www\./i, '').toLowerCase();
     if (!host) return null;
-    return `${host}${pathname || ''}` || host;
+
+    let pathname = url.pathname || '';
+    pathname = pathname.replace(/\/+$/, '');
+    if (pathname && pathname !== '/' && !pathname.startsWith('/')) {
+      pathname = `/${pathname}`;
+    }
+    if (pathname === '/' || pathname === '') {
+      pathname = '';
+    }
+
+    const params = sanitizeQueryParams(url.searchParams);
+    const queryString = params.toString();
+
+    return queryString ? `${host}${pathname}?${queryString}` : `${host}${pathname}`;
   } catch (error) {
     return null;
   }
@@ -90,6 +148,108 @@ export function extractDomain(rawUrl) {
   } catch (error) {
     return null;
   }
+}
+
+/**
+ * Normalize tracking parameters and return a consistently ordered search params object.
+ * @param {URLSearchParams} searchParams
+ * @returns {URLSearchParams}
+ */
+function sanitizeQueryParams(searchParams) {
+  const result = new URLSearchParams();
+  if (!searchParams) return result;
+
+  const keys = Array.from(searchParams.keys());
+  for (const key of keys) {
+    const lower = key.toLowerCase();
+    const hasBlockedPrefix = TRACKING_PARAM_PREFIXES.some((prefix) => lower.startsWith(prefix));
+    if (hasBlockedPrefix || TRACKING_PARAM_NAMES.includes(lower)) {
+      continue;
+    }
+    const values = searchParams.getAll(key);
+    for (const value of values) {
+      result.append(key, value);
+    }
+  }
+
+  // Sort for deterministic order to maximize dedupe accuracy.
+  const sorted = new URLSearchParams();
+  const sortedKeys = Array.from(result.keys()).sort((a, b) => a.localeCompare(b));
+  for (const key of sortedKeys) {
+    const values = result.getAll(key);
+    for (const value of values) {
+      sorted.append(key, value);
+    }
+  }
+  return sorted;
+}
+
+/**
+ * Attempt to convert an arbitrary rule value into a regular expression descriptor.
+ * @param {any} value
+ * @returns {{ pattern: string, flags: string }|null}
+ */
+function normalizeRulePattern(value) {
+  if (!value) return null;
+  if (value instanceof RegExp) {
+    return { pattern: value.source, flags: value.flags || 'i' };
+  }
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) return null;
+    return { pattern: trimmed, flags: 'i' };
+  }
+  if (typeof value === 'object') {
+    const pattern = typeof value.pattern === 'string' ? value.pattern.trim() : '';
+    if (!pattern) return null;
+    const flags = typeof value.flags === 'string' ? value.flags : 'i';
+    return { pattern, flags };
+  }
+  return null;
+}
+
+/**
+ * Parse user-provided rule JSON into normalized rule definitions.
+ * @param {string|undefined|null} jsonString
+ * @returns {Array<{ name: string, host?: {pattern:string,flags:string}, title?: {pattern:string,flags:string}, path?: {pattern:string,flags:string}, color?: string }>}
+ */
+export function parseUserRulesJSON(jsonString) {
+  if (!jsonString) return [];
+  let parsed;
+  try {
+    parsed = JSON.parse(jsonString);
+  } catch (error) {
+    return [];
+  }
+  if (!Array.isArray(parsed)) {
+    return [];
+  }
+
+  const cleaned = [];
+  for (const entry of parsed) {
+    if (!entry || typeof entry !== 'object') continue;
+    const name = typeof entry.name === 'string' ? entry.name.trim() : '';
+    if (!name) continue;
+    const host = normalizeRulePattern(entry.host ?? entry.hostname ?? entry.hostPattern);
+    const title = normalizeRulePattern(entry.title ?? entry.titlePattern);
+    const path = normalizeRulePattern(entry.path ?? entry.pathname ?? entry.pathPattern);
+    if (!host && !title && !path) continue;
+    const color = sanitizeGroupColor(entry.color);
+    cleaned.push({ name, host, title, path, color: color || undefined });
+  }
+  return cleaned;
+}
+
+/**
+ * Ensure a provided color is valid for Chrome tab groups.
+ * @param {any} value
+ * @returns {string|null}
+ */
+function sanitizeGroupColor(value) {
+  if (typeof value !== 'string') return null;
+  const normalized = value.trim().toLowerCase();
+  if (!normalized) return null;
+  return VALID_GROUP_COLORS.has(normalized) ? normalized : null;
 }
 
 /**
@@ -285,4 +445,291 @@ function truncateLabel(label) {
   const trimmed = label.trim().replace(/\s+/g, ' ');
   if (trimmed.length <= 24) return trimmed;
   return `${trimmed.slice(0, 21)}…`;
+}
+
+/**
+ * Convert chrome.tab.Tab entries into TabSnapshots when needed.
+ * @param {Array<chrome.tabs.Tab|TabSnapshot>} tabs
+ * @returns {TabSnapshot[]}
+ */
+function ensureSnapshots(tabs) {
+  if (!Array.isArray(tabs)) return [];
+  return tabs.map((tab) => {
+    if (tab && typeof tab === 'object' && 'windowId' in tab) {
+      return snapshotTab(/** @type {chrome.tabs.Tab} */ (tab));
+    }
+    return /** @type {TabSnapshot} */ (tab);
+  });
+}
+
+/**
+ * Determine which tabs to close using deterministic logic.
+ * @param {Array<chrome.tabs.Tab|TabSnapshot>} tabs
+ * @param {{ preservePinned?: boolean, keepAtLeastOnePerDomain?: boolean }} preferences
+ */
+export function dedupeTabs(tabs, preferences = {}) {
+  const snapshots = ensureSnapshots(tabs);
+  return computeDedupePlan(snapshots, {
+    preservePinned: preferences.preservePinned !== false,
+    keepAtLeastOnePerDomain: preferences.keepAtLeastOnePerDomain !== false
+  });
+}
+
+/**
+ * Build deterministic tab groups using rule-based assignments and domain fallback.
+ * @param {Array<chrome.tabs.Tab|TabSnapshot>} tabs
+ * @param {{
+ *  userRules?: ReturnType<typeof parseUserRulesJSON>,
+ *  maxTabsPerGroup?: number|null,
+ *  preservePinned?: boolean
+ * }} [options]
+ * @returns {{
+ *  groups: Array<{ name: string, tabIds: number[], color?: string, tabs: Array<{id:number,title:string,url:string}>, source: string, sourceValue: string }>,
+ *  summary: Array<{ name: string, count: number, color: string|null }>,
+ *  assignedTabIds: number[],
+ *  leftovers: TabSnapshot[]
+ * }}
+ */
+export function groupByRules(tabs, options = {}) {
+  const snapshots = ensureSnapshots(tabs).slice().sort((a, b) => a.index - b.index);
+  const preservePinned = options.preservePinned !== false;
+  const userRules = Array.isArray(options.userRules) ? options.userRules : [];
+  const limitValue = Number(options.maxTabsPerGroup);
+  const maxTabsPerGroup = Number.isFinite(limitValue) && limitValue >= 2 ? Math.floor(limitValue) : 0;
+
+  const ruleMatchers = buildRuleMatchers(userRules);
+  const state = { buckets: new Map(), ordered: [] };
+  /** @type {Map<string, TabSnapshot[]>} */
+  const fallbackCandidates = new Map();
+
+  for (const tab of snapshots) {
+    if (preservePinned && tab.pinned) {
+      continue;
+    }
+    const parts = getUrlParts(tab.url);
+    const match = matchRule(ruleMatchers, tab, parts);
+    if (match) {
+      assignTabToBucket(state, match, tab, maxTabsPerGroup);
+      continue;
+    }
+    const domainKey = parts.host || extractDomain(tab.url) || '';
+    if (!fallbackCandidates.has(domainKey)) {
+      fallbackCandidates.set(domainKey, []);
+    }
+    fallbackCandidates.get(domainKey).push(tab);
+  }
+
+  /** @type {TabSnapshot[]} */
+  const leftovers = [];
+
+  for (const [domainKey, domainTabs] of fallbackCandidates.entries()) {
+    const eligibleTabs = domainTabs.filter((tab) => !(preservePinned && tab.pinned));
+    if (eligibleTabs.length < 2) {
+      leftovers.push(...eligibleTabs);
+      continue;
+    }
+    const baseName = truncateLabel(domainToLabel(domainKey) || 'Other');
+    const baseKey = domainKey || 'other';
+    let chunkIndex = 0;
+    let cursor = 0;
+    const limit = maxTabsPerGroup && maxTabsPerGroup > 1 ? maxTabsPerGroup : 0;
+    while (cursor < eligibleTabs.length) {
+      const remaining = eligibleTabs.length - cursor;
+      const chunkSize = limit ? Math.min(limit, remaining) : remaining;
+      if (chunkSize < 2) {
+        leftovers.push(...eligibleTabs.slice(cursor));
+        break;
+      }
+      const chunkTabs = eligibleTabs.slice(cursor, cursor + chunkSize);
+      const descriptor = {
+        key: `domain:${baseKey}:${chunkIndex}`,
+        baseName: chunkIndex === 0 ? baseName : truncateLabel(`${baseName} (${chunkIndex + 1})`),
+        color: undefined,
+        source: 'domain',
+        sourceValue: domainKey || 'Other'
+      };
+      for (const tab of chunkTabs) {
+        assignTabToBucket(state, descriptor, tab, maxTabsPerGroup);
+      }
+      cursor += chunkSize;
+      chunkIndex += 1;
+    }
+  }
+
+  const finalGroups = [];
+  for (const bucket of state.ordered) {
+    if (bucket.source === 'domain' && bucket.tabIds.length < 2) {
+      leftovers.push(
+        ...bucket.tabs.map((tab) => ({
+          id: tab.id,
+          title: tab.title,
+          url: tab.url,
+          pinned: false,
+          audible: false,
+          active: false,
+          groupId: -1,
+          index: 0,
+          lastAccessed: undefined
+        }))
+      );
+      continue;
+    }
+    finalGroups.push({
+      name: bucket.name,
+      tabIds: bucket.tabIds.slice(),
+      color: bucket.color,
+      tabs: bucket.tabs.map((tab) => ({ ...tab })),
+      source: bucket.source,
+      sourceValue: bucket.sourceValue
+    });
+  }
+
+  const assignedTabIds = finalGroups.flatMap((group) => group.tabIds.slice());
+  const summary = finalGroups.map((group) => ({
+    name: group.name,
+    count: group.tabIds.length,
+    color: group.color || null
+  }));
+
+  return { groups: finalGroups, summary, assignedTabIds, leftovers };
+}
+
+/**
+ * Create compiled rule matchers from built-in and custom definitions.
+ * @param {Array<{name:string, host?:any, title?:any, path?:any, color?:string}>} userRules
+ */
+function buildRuleMatchers(userRules) {
+  const matchers = [];
+  let counter = 0;
+  for (const rule of userRules || []) {
+    const matcher = createRuleMatcher(rule, `user-${counter++}`);
+    if (matcher) matchers.push(matcher);
+  }
+  for (const rule of DEFAULT_RULE_DEFINITIONS) {
+    const matcher = createRuleMatcher(rule, `default-${counter++}`);
+    if (matcher) matchers.push(matcher);
+  }
+  return matchers;
+}
+
+/**
+ * Build a single rule matcher instance.
+ * @param {{name?:string, host?:any, title?:any, path?:any, color?:string}} rule
+ * @param {string} key
+ */
+function createRuleMatcher(rule, key) {
+  if (!rule || typeof rule !== 'object') return null;
+  const name = typeof rule.name === 'string' ? rule.name.trim() : '';
+  if (!name) return null;
+  const host = compileRulePattern(rule.host ?? rule.hostname ?? rule.hostPattern);
+  const title = compileRulePattern(rule.title ?? rule.titlePattern);
+  const path = compileRulePattern(rule.path ?? rule.pathname ?? rule.pathPattern);
+  if (!host && !title && !path) return null;
+  const color = sanitizeGroupColor(rule.color);
+  return {
+    key,
+    baseName: truncateLabel(name),
+    color: color || undefined,
+    host,
+    title,
+    path
+  };
+}
+
+/**
+ * Convert any pattern descriptor into a RegExp instance.
+ * @param {any} descriptor
+ * @returns {RegExp|null}
+ */
+function compileRulePattern(descriptor) {
+  const normalized = normalizeRulePattern(descriptor);
+  if (!normalized) return null;
+  try {
+    return new RegExp(normalized.pattern, normalized.flags || 'i');
+  } catch (error) {
+    return null;
+  }
+}
+
+/**
+ * Match a tab against prioritized rule matchers.
+ * @param {Array<{key:string, baseName:string, color?:string, host?:RegExp|null, title?:RegExp|null, path?:RegExp|null}>} ruleMatchers
+ * @param {TabSnapshot} tab
+ * @param {{host: string, path: string}} parts
+ */
+function matchRule(ruleMatchers, tab, parts) {
+  for (const matcher of ruleMatchers) {
+    if (matcher.host && !matcher.host.test(parts.host)) continue;
+    if (matcher.title && !matcher.title.test(tab.title || '')) continue;
+    if (matcher.path && !matcher.path.test(parts.path)) continue;
+    return {
+      key: matcher.key,
+      baseName: matcher.baseName,
+      color: matcher.color,
+      source: 'rule',
+      sourceValue: matcher.baseName
+    };
+  }
+  return null;
+}
+
+/**
+ * Assign a tab to the correct bucket, enforcing max tabs per group when present.
+ * @param {{ buckets: Map<string, any[]>, ordered: any[] }} state
+ * @param {{ key?: string, baseName: string, color?: string, source?: string, sourceValue?: string }} descriptor
+ * @param {TabSnapshot} tab
+ * @param {number} maxTabsPerGroup
+ */
+function assignTabToBucket(state, descriptor, tab, maxTabsPerGroup) {
+  const key = descriptor.key || `${descriptor.source || 'rule'}:${descriptor.baseName}:${descriptor.color || ''}`;
+  let bucketList = state.buckets.get(key);
+  if (!bucketList) {
+    bucketList = [];
+    state.buckets.set(key, bucketList);
+  }
+  const limit = maxTabsPerGroup && maxTabsPerGroup >= 2 ? maxTabsPerGroup : 0;
+  let bucket = bucketList[bucketList.length - 1];
+  if (!bucket || (limit && bucket.tabIds.length >= limit)) {
+    const index = bucketList.length;
+    const baseName = descriptor.baseName || 'Group';
+    const label = index === 0 ? baseName : truncateLabel(`${baseName} (${index + 1})`);
+    bucket = {
+      name: truncateLabel(label),
+      color: descriptor.color,
+      source: descriptor.source || 'rule',
+      sourceValue: descriptor.sourceValue || baseName,
+      tabIds: [],
+      tabs: []
+    };
+    bucketList.push(bucket);
+    state.ordered.push(bucket);
+  }
+  bucket.tabIds.push(tab.id);
+  bucket.tabs.push({ id: tab.id, title: tab.title, url: tab.url });
+}
+
+/**
+ * Provide host/path parts for a URL.
+ * @param {string} rawUrl
+ */
+function getUrlParts(rawUrl) {
+  try {
+    const url = new URL(rawUrl);
+    const host = url.hostname.replace(/^www\./i, '').toLowerCase();
+    const path = url.pathname || '/';
+    return { host, path };
+  } catch (error) {
+    return { host: '', path: '' };
+  }
+}
+
+/**
+ * Convert a hostname into a compact grouping label.
+ * @param {string} domain
+ */
+function domainToLabel(domain) {
+  if (!domain) return 'Other';
+  const parts = domain.split('.');
+  if (parts.length <= 2) return domain;
+  return parts.slice(-2).join('.');
 }


### PR DESCRIPTION
## Summary
- add deterministic no-LLM planning and execution in the background worker with new tab utility helpers
- expose offline organizing controls in the popup alongside the existing LLM workflow
- extend the options page and documentation with No-LLM configuration, dry-run defaults, and rule JSON support

## Testing
- no tests (not available)

------
https://chatgpt.com/codex/tasks/task_e_68ca41007bf8833394b10ab45a5653d1