### PR TITLE
Ensure service worker scripts avoid modern nullish syntax

### DIFF
--- a/llm.js
+++ b/llm.js
@@ -64,11 +64,13 @@ export async function requestChatCompletion(params) {
  * @returns {string}
  */
 export function extractMessageContent(completion) {
-  const choice = completion?.choices?.[0];
+  const choices = completion && Array.isArray(completion.choices) ? completion.choices : [];
+  const choice = choices[0];
   if (!choice) {
     throw new Error('Unexpected OpenAI response format.');
   }
-  const content = choice.message?.content;
+  const message = choice.message ? choice.message : null;
+  const content = message && typeof message.content === 'string' ? message.content : undefined;
   if (typeof content !== 'string' || !content.trim()) {
     throw new Error('OpenAI response did not include content.');
   }

--- a/service_worker.js
+++ b/service_worker.js
@@ -12,7 +12,10 @@ import {
 
 const RATE_LIMIT_INTERVAL_MS = 5000;
 const PREVIEW_TTL_MS = 5 * 60 * 1000;
-const TAB_GROUP_ID_NONE = chrome.tabGroups?.TAB_GROUP_ID_NONE ?? -1;
+const TAB_GROUP_ID_NONE =
+  chrome.tabGroups && typeof chrome.tabGroups.TAB_GROUP_ID_NONE === 'number'
+    ? chrome.tabGroups.TAB_GROUP_ID_NONE
+    : -1;
 
 const DEFAULT_SYNC_SETTINGS = {
   apiKey: '',


### PR DESCRIPTION
## Summary
- replace optional chaining on the service worker tab group constant with an explicit chrome.tabGroups guard
- update the OpenAI response parser to avoid optional chaining when reading choices and message content
- add a firstDefined helper and refactor tab utility logic to remove nullish coalescing and optional chaining throughout grouping, scoring, and serialization code

## Testing
- node --check service_worker.js
- node --check llm.js
- node --check tab_utils.js

------
https://chatgpt.com/codex/tasks/task_e_68ca70eda4748333b09c82d295b15036