### PR TITLE
Revamp popup layout and add settings access

### DIFF
--- a/popup.css
+++ b/popup.css
@@ -68,6 +68,13 @@ body::before {
   transform: translateY(-2px);
 }
 
+.panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
 .panel-header h1 {
   margin: 0;
   font-size: 1.35rem;
@@ -75,10 +82,49 @@ body::before {
   letter-spacing: -0.01em;
 }
 
+.settings-button {
+  appearance: none;
+  border: 1px solid rgba(255, 255, 255, 0.75);
+  border-radius: 999px;
+  padding: 6px 14px;
+  font-size: 0.82rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  background: rgba(255, 255, 255, 0.65);
+  color: var(--text-secondary);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.65), 0 10px 18px rgba(15, 23, 42, 0.08);
+  transition: transform 200ms ease, box-shadow 200ms ease, background 200ms ease;
+}
+
+.settings-button:hover {
+  transform: translateY(-1px);
+  background: rgba(255, 255, 255, 0.78);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.7), 0 14px 26px rgba(15, 23, 42, 0.12);
+}
+
+.settings-button:active {
+  transform: translateY(0);
+}
+
+.settings-button:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.9), 0 0 0 5px rgba(99, 102, 241, 0.35);
+}
+
 .organize-form {
   display: flex;
   flex-direction: column;
-  gap: 18px;
+  gap: 20px;
+}
+
+.llm-section {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
 }
 
 .field {
@@ -126,24 +172,120 @@ textarea:disabled {
   opacity: 0.6;
 }
 
-.button-row {
+.primary-actions {
   display: flex;
   flex-wrap: wrap;
+  gap: 10px;
+  align-items: stretch;
+}
+
+.primary-actions .glass-button {
+  flex: 1 1 160px;
+}
+
+.primary-actions #close-duplicates {
+  flex: 0 1 auto;
+  min-width: 150px;
+}
+
+.nolllm-section {
+  padding-top: 10px;
+  border-top: 1px solid rgba(148, 163, 184, 0.22);
+}
+
+.nolllm-section .glass-button {
+  width: 100%;
+}
+
+.toggle-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
   gap: 12px;
+}
+
+.toggle-row .toggle-control {
+  flex: 1;
+}
+
+.tooltip-container {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+}
+
+.tooltip-trigger {
+  appearance: none;
+  border: none;
+  border-radius: 999px;
+  width: 24px;
+  height: 24px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.78rem;
+  font-weight: 700;
+  color: var(--text-secondary);
+  background: rgba(255, 255, 255, 0.7);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.65), 0 10px 18px rgba(15, 23, 42, 0.12);
+  cursor: help;
+  transition: transform 200ms ease, box-shadow 200ms ease, background 200ms ease;
+}
+
+.tooltip-trigger:hover,
+.tooltip-container:focus-within .tooltip-trigger {
+  transform: translateY(-1px);
+  background: rgba(255, 255, 255, 0.85);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.72), 0 14px 26px rgba(15, 23, 42, 0.16);
+}
+
+.tooltip-trigger:active {
+  transform: translateY(0);
+}
+
+.tooltip-trigger:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.9), 0 0 0 5px rgba(99, 102, 241, 0.35);
+}
+
+.tooltip-bubble {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  width: 220px;
+  max-width: 70vw;
+  padding: 10px 12px;
+  border-radius: 12px;
+  background: rgba(15, 23, 42, 0.92);
+  color: #f8fafc;
+  font-size: 0.78rem;
+  line-height: 1.45;
+  box-shadow: 0 18px 32px rgba(15, 23, 42, 0.25);
+  opacity: 0;
+  transform: translateY(-4px);
+  pointer-events: none;
+  transition: opacity 160ms ease, transform 160ms ease;
+  z-index: 2;
+}
+
+.tooltip-container:hover .tooltip-bubble,
+.tooltip-container:focus-within .tooltip-bubble {
+  opacity: 1;
+  transform: translateY(0);
 }
 
 .glass-button {
   appearance: none;
   border: none;
   border-radius: 999px;
-  padding: 12px 20px;
-  font-size: 0.97rem;
+  padding: 10px 18px;
+  font-size: 0.9rem;
   font-weight: 600;
   letter-spacing: 0.01em;
   color: #ffffff;
   cursor: pointer;
-  flex: 1 1 150px;
-  min-height: 44px;
+  flex: 1 1 140px;
+  min-height: 40px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -339,8 +481,27 @@ textarea:disabled {
     padding: 22px 18px 24px;
   }
 
-  .button-row {
+  .primary-actions {
     flex-direction: column;
+  }
+
+  .primary-actions .glass-button,
+  .nolllm-section .glass-button {
+    width: 100%;
+  }
+
+  .primary-actions #close-duplicates {
+    min-width: 0;
+  }
+
+  .toggle-row {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 10px;
+  }
+
+  .tooltip-container {
+    align-self: flex-start;
   }
 }
 

--- a/popup.html
+++ b/popup.html
@@ -10,29 +10,49 @@
     <main class="glass-panel">
       <header class="panel-header">
         <h1>Organize tabs</h1>
+        <button type="button" id="open-settings" class="settings-button">⚙ Settings</button>
       </header>
       <form id="organize-form" class="organize-form">
-        <div class="field">
-          <label for="organize-input">Tell me how to organize</label>
-          <textarea
-            id="organize-input"
-            name="prompt"
-            rows="4"
-            placeholder="e.g., Group by project and close social media duplicates"
-          ></textarea>
+        <div class="llm-section">
+          <div class="field">
+            <label for="organize-input">Tell me how to organize</label>
+            <textarea
+              id="organize-input"
+              name="prompt"
+              rows="4"
+              placeholder="e.g., Group by project and close social media duplicates"
+            ></textarea>
+          </div>
+          <div class="primary-actions">
+            <button type="submit" id="organize-llm" class="glass-button accent">Organize (LLM)</button>
+            <button type="button" id="close-duplicates" class="glass-button danger">Close duplicates</button>
+          </div>
         </div>
-        <div class="button-row">
-          <button type="submit" id="organize-llm" class="glass-button accent">Organize (LLM)</button>
+        <div class="nolllm-section">
           <button type="button" id="organize-nollm" class="glass-button outline">Organize (No-LLM)</button>
-          <button type="button" id="close-duplicates" class="glass-button danger">Close duplicates</button>
         </div>
-        <label class="toggle-control" for="dryRunNoLLM">
-          <input type="checkbox" id="dryRunNoLLM" name="dryRunNoLLM" />
-          <span class="toggle-track" aria-hidden="true">
-            <span class="toggle-thumb"></span>
-          </span>
-          <span class="toggle-label">Dry-run (No-LLM)</span>
-        </label>
+        <div class="toggle-row">
+          <label class="toggle-control" for="dryRunNoLLM">
+            <input type="checkbox" id="dryRunNoLLM" name="dryRunNoLLM" />
+            <span class="toggle-track" aria-hidden="true">
+              <span class="toggle-thumb"></span>
+            </span>
+            <span class="toggle-label">Dry-run (No-LLM)</span>
+          </label>
+          <div class="tooltip-container">
+            <button
+              type="button"
+              class="tooltip-trigger"
+              aria-label="Learn about dry-run"
+              aria-describedby="dry-run-tooltip"
+            >
+              ?
+            </button>
+            <div id="dry-run-tooltip" class="tooltip-bubble" role="tooltip">
+              Dry-run shows you what would happen without actually closing or grouping tabs.
+            </div>
+          </div>
+        </div>
       </form>
       <section id="preview" class="preview-panel" hidden>
         <h2>Planned changes</h2>

--- a/popup.js
+++ b/popup.js
@@ -3,6 +3,7 @@ const textarea = document.getElementById('organize-input');
 const llmButton = document.getElementById('organize-llm');
 const noLlmButton = document.getElementById('organize-nollm');
 const closeDuplicatesButton = document.getElementById('close-duplicates');
+const settingsButton = document.getElementById('open-settings');
 const dryRunNoLlmCheckbox = document.getElementById('dryRunNoLLM');
 const statusEl = document.getElementById('status');
 const previewSection = document.getElementById('preview');
@@ -15,6 +16,16 @@ let cachedUserRules = '';
 let llmDryRunPreference = false;
 
 initializePopup();
+
+if (settingsButton) {
+  settingsButton.addEventListener('click', () => {
+    if (chrome.runtime.openOptionsPage) {
+      chrome.runtime.openOptionsPage();
+    } else {
+      window.open(chrome.runtime.getURL('options.html'));
+    }
+  });
+}
 
 form.addEventListener('submit', async (event) => {
   event.preventDefault();


### PR DESCRIPTION
## Summary
- add a dedicated settings pill in the popup header that opens the options page
- regroup the prompt area with the LLM and duplicate-closing actions while sizing buttons consistently
- surface a dry-run tooltip with hover/focus support and responsive styling tweaks

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68ca944f13e48333a9ba111be0e898e5