### PR TITLE
Enhance duplicate handling and popup UI

### DIFF
--- a/popup.css
+++ b/popup.css
@@ -174,18 +174,12 @@ textarea:disabled {
 
 .primary-actions {
   display: flex;
-  flex-wrap: wrap;
+  flex-direction: column;
   gap: 10px;
-  align-items: stretch;
 }
 
 .primary-actions .glass-button {
-  flex: 1 1 160px;
-}
-
-.primary-actions #close-duplicates {
-  flex: 0 1 auto;
-  min-width: 150px;
+  width: 100%;
 }
 
 .nolllm-section {
@@ -194,6 +188,14 @@ textarea:disabled {
 }
 
 .nolllm-section .glass-button {
+  width: 100%;
+}
+
+.dedupe-section {
+  display: flex;
+}
+
+.dedupe-section .glass-button {
   width: 100%;
 }
 
@@ -249,11 +251,11 @@ textarea:disabled {
 }
 
 .tooltip-bubble {
-  position: absolute;
-  top: calc(100% + 8px);
-  right: 0;
-  width: 220px;
-  max-width: 70vw;
+  position: fixed;
+  left: 0;
+  top: 0;
+  width: max-content;
+  max-width: min(240px, calc(100vw - 16px));
   padding: 10px 12px;
   border-radius: 12px;
   background: rgba(15, 23, 42, 0.92);
@@ -262,15 +264,16 @@ textarea:disabled {
   line-height: 1.45;
   box-shadow: 0 18px 32px rgba(15, 23, 42, 0.25);
   opacity: 0;
+  visibility: hidden;
   transform: translateY(-4px);
   pointer-events: none;
   transition: opacity 160ms ease, transform 160ms ease;
   z-index: 2;
 }
 
-.tooltip-container:hover .tooltip-bubble,
-.tooltip-container:focus-within .tooltip-bubble {
+.tooltip-bubble[data-visible='true'] {
   opacity: 1;
+  visibility: visible;
   transform: translateY(0);
 }
 
@@ -481,17 +484,10 @@ textarea:disabled {
     padding: 22px 18px 24px;
   }
 
-  .primary-actions {
-    flex-direction: column;
-  }
-
   .primary-actions .glass-button,
-  .nolllm-section .glass-button {
+  .nolllm-section .glass-button,
+  .dedupe-section .glass-button {
     width: 100%;
-  }
-
-  .primary-actions #close-duplicates {
-    min-width: 0;
   }
 
   .toggle-row {

--- a/popup.html
+++ b/popup.html
@@ -25,11 +25,13 @@
           </div>
           <div class="primary-actions">
             <button type="submit" id="organize-llm" class="glass-button accent">Organize (LLM)</button>
-            <button type="button" id="close-duplicates" class="glass-button danger">Close duplicates</button>
           </div>
         </div>
         <div class="nolllm-section">
           <button type="button" id="organize-nollm" class="glass-button outline">Organize (No-LLM)</button>
+        </div>
+        <div class="dedupe-section">
+          <button type="button" id="close-duplicates" class="glass-button danger">Close duplicates</button>
         </div>
         <div class="toggle-row">
           <label class="toggle-control" for="dryRunNoLLM">

--- a/service_worker.js
+++ b/service_worker.js
@@ -52,7 +52,7 @@ async function initializeActionIcon() {
   }
 
   try {
-    const response = await fetch(chrome.runtime.getURL('TabOrgAI.png'));
+    const response = await fetch(chrome.runtime.getURL('logo.png'));
     if (!response.ok) {
       throw new Error(`Failed to load logo asset (${response.status})`);
     }


### PR DESCRIPTION
## Summary
- add an explicit list of important categories and extend duplicate closing to collapse non-important domains
- refine the popup layout by resizing/reordering buttons, keeping the tooltip in view, and only showing planned changes when real data is available
- switch the toolbar icon loader to logo.png so the extension consistently uses the intended logo

## Testing
- not run (Chrome extension)


------
https://chatgpt.com/codex/tasks/task_e_68ca9ce701608333be2ba0aa8d0bc687