### PR TITLE
Adjust LLM organize button sizing

### DIFF
--- a/popup.css
+++ b/popup.css
@@ -179,6 +179,7 @@ textarea:disabled {
 }
 
 .primary-actions .glass-button {
+  flex: 0 0 auto;
   width: 100%;
 }
 


### PR DESCRIPTION
## Summary
- prevent the Organize (LLM) button from stretching vertically inside its column layout so it matches the other action buttons

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68caa1cddbfc8333b09262ec14701565