### PR TITLE
Keep dry-run tooltip beside toggle on mobile

### DIFF
--- a/popup.css
+++ b/popup.css
@@ -492,13 +492,12 @@ textarea:disabled {
   }
 
   .toggle-row {
-    flex-direction: column;
-    align-items: stretch;
+    align-items: center;
     gap: 10px;
   }
 
   .tooltip-container {
-    align-self: flex-start;
+    align-self: center;
   }
 }
 


### PR DESCRIPTION
## Summary
- keep the dry-run tooltip button inline with its toggle on small viewports so it no longer drops below the control
- center the tooltip container alignment within the mobile media query to maintain consistent vertical positioning

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68caa39119a08333b4c02a7759ab30b8